### PR TITLE
expect json for POST /api/courses/${slug}/assign/

### DIFF
--- a/teleband/courses/api/views.py
+++ b/teleband/courses/api/views.py
@@ -1,6 +1,7 @@
 import collections
 import csv
 from io import StringIO
+import json
 import logging
 
 from django.contrib.auth import get_user_model
@@ -212,19 +213,18 @@ class CourseViewSet(RetrieveModelMixin, CreateModelMixin, GenericViewSet):
 
     @action(detail=True, methods=["post"])
     def assign(self, request, **kwargs):
-        if "piece_id" not in request.POST:
+        parsed = json.loads(request.body)
+        if "piece_id" not in parsed:
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"error": "Missing piece_id in POST data"},
             )
 
         try:
-            piece = Piece.objects.get(pk=request.POST["piece_id"])
+            piece = Piece.objects.get(pk=parsed["piece_id"])
         except Piece.DoesNotExist:
             logger.info(
-                "Attempt to assign non-existent piece {}".format(
-                    request.POST["piece_id"]
-                )
+                "Attempt to assign non-existent piece {}".format(parsed["piece_id"])
             )
             return Response(status=status.HTTP_404_NOT_FOUND)
 


### PR DESCRIPTION
like this? I think i got farther with this (btw, it wasn't `json.loads` on `request.POST`, but rather on body), but I can't confirm this worked, because I got the following error, that could again be due to weird db artifacts on my end or could be a bug. any ideas?

```
Internal Server Error: /api/courses/6th-grade-band/assign/
Traceback (most recent call last):
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.NotNullViolation: null value in column "instrument_id" of relation "assignments_assignment" violates not-null constraint
DETAIL:  Failing row contains (3, null, 1, null, 2022-01-18 05:29:48.24836+00, 19, 1).


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/tgm/.pyenv/versions/3.10.0/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/rest_framework/viewsets.py", line 125, in view
    return self.dispatch(request, *args, **kwargs)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/Users/tgm/dev/CPR-Music-Backend/teleband/courses/api/views.py", line 239, in assign
    Assignment.objects.create(
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/query.py", line 453, in create
    obj.save(force_insert=True, using=self.db)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/base.py", line 739, in save
    self.save_base(using=using, force_insert=force_insert,
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/base.py", line 776, in save_base
    updated = self._save_table(
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/base.py", line 881, in _save_table
    results = self._do_insert(cls._base_manager, using, fields, returning_fields, raw)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/base.py", line 919, in _do_insert
    return manager._insert(
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/query.py", line 1270, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/sql/compiler.py", line 1416, in execute_sql
    cursor.execute(sql, params)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/debug_toolbar/panels/sql/tracking.py", line 205, in execute
    return self._record(self.cursor.execute, sql, params)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/debug_toolbar/panels/sql/tracking.py", line 140, in _record
    return method(sql, params)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/backends/utils.py", line 98, in execute
    return super().execute(sql, params)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/backends/utils.py", line 79, in _execute
    with self.db.wrap_database_errors:
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
django.db.utils.IntegrityError: null value in column "instrument_id" of relation "assignments_assignment" violates not-null constraint
DETAIL:  Failing row contains (3, null, 1, null, 2022-01-18 05:29:48.24836+00, 19, 1).

ERROR 2022-01-18 00:29:48,488 django.request 28350 13036961792 Internal Server Error: /api/courses/6th-grade-band/assign/
Traceback (most recent call last):
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
psycopg2.errors.NotNullViolation: null value in column "instrument_id" of relation "assignments_assignment" violates not-null constraint
DETAIL:  Failing row contains (3, null, 1, null, 2022-01-18 05:29:48.24836+00, 19, 1).


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/Users/tgm/.pyenv/versions/3.10.0/lib/python3.10/contextlib.py", line 79, in inner
    return func(*args, **kwds)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/views/decorators/csrf.py", line 54, in wrapped_view
    return view_func(*args, **kwargs)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/rest_framework/viewsets.py", line 125, in view
    return self.dispatch(request, *args, **kwargs)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/Users/tgm/dev/CPR-Music-Backend/teleband/courses/api/views.py", line 239, in assign
    Assignment.objects.create(
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/query.py", line 453, in create
    obj.save(force_insert=True, using=self.db)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/base.py", line 739, in save
    self.save_base(using=using, force_insert=force_insert,
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/base.py", line 776, in save_base
    updated = self._save_table(
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/base.py", line 881, in _save_table
    results = self._do_insert(cls._base_manager, using, fields, returning_fields, raw)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/base.py", line 919, in _do_insert
    return manager._insert(
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/query.py", line 1270, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/models/sql/compiler.py", line 1416, in execute_sql
    cursor.execute(sql, params)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/debug_toolbar/panels/sql/tracking.py", line 205, in execute
    return self._record(self.cursor.execute, sql, params)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/debug_toolbar/panels/sql/tracking.py", line 140, in _record
    return method(sql, params)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/backends/utils.py", line 98, in execute
    return super().execute(sql, params)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/backends/utils.py", line 79, in _execute
    with self.db.wrap_database_errors:
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/Users/tgm/.pyenv/versions/CPR-Music-Backend/lib/python3.10/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
django.db.utils.IntegrityError: null value in column "instrument_id" of relation "assignments_assignment" violates not-null constraint
DETAIL:  Failing row contains (3, null, 1, null, 2022-01-18 05:29:48.24836+00, 19, 1).

```