### PR TITLE
Add category name to activity_type serializer

### DIFF
--- a/teleband/assignments/api/serializers.py
+++ b/teleband/assignments/api/serializers.py
@@ -1,13 +1,21 @@
 from rest_framework import serializers
 
-from teleband.assignments.models import Assignment, Activity
+from teleband.assignments.models import Assignment, Activity, ActivityType
 from teleband.instruments.api.serializers import InstrumentSerializer
 from teleband.utils.serializers import GenericNameSerializer
 from teleband.musics.api.serializers import PartTranspositionSerializer, PartSerializer
 
 
+class ActivityTypeSerializer(serializers.ModelSerializer):
+    category = GenericNameSerializer()
+
+    class Meta:
+        model = ActivityType
+        fields = ["name", "category"]
+
+
 class ActivitySerializer(serializers.ModelSerializer):
-    activity_type = GenericNameSerializer()
+    activity_type = ActivityTypeSerializer()
     part_type = GenericNameSerializer()
 
     class Meta:


### PR DESCRIPTION
This breaks the old schema by changing

```
activity_type: <name>
```

into

```
activity_type: {
    name: <name>,
    category: <category_name>
}
```

Ok?